### PR TITLE
Add setup.py to allow pip install

### DIFF
--- a/src/setup.py
+++ b/src/setup.py
@@ -1,9 +1,10 @@
-from setuptools import setup
+import setuptools
 
-setup(name='bitio',
-      version='0.48c',
+setuptools.setup(name='bitio',
+      version='0.50c',
       description='micro:bit I/O library for Python',
       url='https://github.com/whaleygeek/bitio',
       author='David Whale',
       license='MIT',
-      packages=['microbit'])
+      packages=setuptools.find_packages()
+)

--- a/src/setup.py
+++ b/src/setup.py
@@ -1,0 +1,9 @@
+from setuptools import setup
+
+setup(name='bitio',
+      version='0.48c',
+      description='micro:bit I/O library for Python',
+      url='https://github.com/whaleygeek/bitio',
+      author='David Whale',
+      license='MIT',
+      packages=['microbit'])


### PR DESCRIPTION
I've added `setup.py` file to allow users to run `pip install src\.` and install bitio easily. I've set `version` variable to `0.50c`, because this will be the 50th commit if it's merged. Version variable may change and further improvements to the setup.py may be needed in order to upload to PyPI.

Uploading bitio package to PyPI to simply allow `pip install bitio` can be done using twine and documented on [Python Packaging User Guide on Python.org](https://packaging.python.org/tutorials/packaging-projects/#uploading-the-distribution-archives).