### PR TITLE
Add an ability to choose the micro:bit port using environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,12 @@ Your micro:bit has been detected
 Now running your program
 ```
 
+You could also specify the connected port by setting the environment variable
+`BITIO_PORT`:
+
+- Windows ```set BITIO_PORT=COM7```
+- GNU/Linux ```export BITIO_PORT=COM7```
+
 Finally, you should get a counter counting from 00 to 99 in the WhaleySans font
 (2x5 sized digits) on the display.
 

--- a/src/microbit/portscan/__init__.py
+++ b/src/microbit/portscan/__init__.py
@@ -183,6 +183,8 @@ def getName(device_name=None):
   """read the remembered cached named, None if none stored"""
   if device_name is None:
     device_name = DEFAULT_DEVICE_NAME
+  if os.environ.get("BITIO_PORT"):
+    return os.environ.get("BITIO_PORT")
   try:
     f = open(CACHE_NAME, "r")
     name = f.readline().strip()


### PR DESCRIPTION
Pull request for #40 

Works by setting the env variable `PORT`
